### PR TITLE
Adds plaintext validation 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,6 @@ ark-serialize = "0.2.0"
 ark-std = "0.2.0"
 ark-bls12-381 = "0.2.0"
 
-bls-crypto = { git = "https://github.com/sikkatech/celo-bls-snark-rs", branch="make_hashes_have_new_fn", default-features = false }
-algebra = { git = "https://github.com/celo-org/zexe", features = ["derive", "bls12_377", "ed_on_bw6_761", "parallel"] }
 miracl_core = "2.3.0"
 
 [dev-dependencies]


### PR DESCRIPTION
We include the (encrypted) digest of the plaintext in the ciphertext. After decryption we validate the recovered plaintext against the decrypted digest