### PR TITLE
Pins dependency versions 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,31 +9,31 @@ repository = "https://github.com/heliaxdev/arkworks-threshold-decryption/"
 readme = "README.md"
 
 [dependencies]
-num = "0.4.0"
-log = "0.4.6"
-thiserror = "1.0.14"
-hex = "0.4.3"
-zeroize = "1.3.0"
-rand_core = { version = "0.5" }
-rand = "0.7.3"
-chacha20 = { version = "0.6.0" }
-blake2b_simd = "0.5.11"
-serde = { version = "1.0", features = ["derive"] }
-serde_bytes = { version = "0.11" }
-rayon = "1.5.0"
+num = "=0.4.0"
+log = "=0.4.6"
+thiserror = "=1.0.14"
+hex = "=0.4.3"
+zeroize = "=1.3.0"
+rand_core = { version = "=0.5" }
+rand = "=0.7.3"
+chacha20 = { version = "=0.6.0" }
+blake2b_simd = "=0.5.11"
+serde = { version = "=1.0", features = ["derive"] }
+serde_bytes = { version = "=0.11" }
+rayon = "=1.5.0"
 
-ark-ff = "0.2.0"
-ark-ec = "0.2.0"
-ark-poly = "0.2.0"
-ark-serialize = "0.2.0"
-ark-std = "0.2.0"
-ark-bls12-381 = "0.2.0"
+ark-ff = "=0.2.0"
+ark-ec = "=0.2.0"
+ark-poly = "=0.2.0"
+ark-serialize = "=0.2.0"
+ark-std = "=0.2.0"
+ark-bls12-381 = "=0.2.0"
 
-miracl_core = "2.3.0"
+miracl_core = "=2.3.0"
 
 [dev-dependencies]
-criterion = "0.3.4"
-bincode = "1.3"
+criterion = "=0.3.4"
+bincode = "=1.3"
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
Cargo updates dependency versions by default unless we explicitly pin them using `=`. This introduced a breaking change in one dependency that in turn broke tests https://github.com/heliaxdev/arkworks-threshold-decryption/issues/27.

This PR pins all dependencies to specific versions (for now) that are proven to work.